### PR TITLE
refactor: Merge template and crowsnet containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/settings.json
+ssh-keys/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,14 @@ RUN addgroup -S ansible && adduser -S ansible -G ansible \
   && mkdir -p /home/ansible/.ssh && chown ansible:ansible /home/ansible/.ssh \
   && chmod 0700 /home/ansible/.ssh
 
-# I have commented this next part out, as this Dockerfile is intended to build
-# a template image. This template is designed to be used with multiple ansible
-# instances using different SSH keys. These lines should be run AS ROOT in 
-# downstream Dockerfiles
-
 # Copy SSH keys to ansible .ssh directory
-#COPY ./ssh-keys/ansible_rsa /home/ansible/.ssh/id_rsa
-#COPY ./ssh-keys/ansible_rsa.pub /home/ansible/.ssh/id_rsa.pub
+COPY ./ssh-keys/ansible_ed25519 /home/ansible/.ssh/id_ed25519
+COPY ./ssh-keys/ansible_ed25519.pub /home/ansible/.ssh/id_ed25519.pub
 
 # Set SSH key permissions
-#RUN chown ansible:ansible /home/ansible/.ssh/id_rsa* \
-#  && chmod 600 /home/ansible/.ssh/id_rsa \
-#  && chmod 644 /home/ansible/.ssh/id_rsa.pub
+RUN chown ansible:ansible /home/ansible/.ssh/id_ed25519* \
+  && chmod 600 /home/ansible/.ssh/id_ed25519 \
+  && chmod 644 /home/ansible/.ssh/id_ed25519.pub
 
 # Switch to ansible user
 USER ansible
@@ -46,9 +41,6 @@ ENV ANSIBLE_GATHERING smart
 ENV ANSIBLE_RETRY_FILES_ENABLED false
 ENV ANSIBLE_PYTHON_INTERPRETER auto_silent
 
-# Switch back to root user
-USER root
-
-# Set 'entrypoint.sh' as the default entrypoint. I have also commented this out, to be set downstream
-#COPY ./entrypoint.sh /entrypoint.sh
-#ENTRYPOINT["bash","/entrypoint.sh"]
+# Set 'entrypoint.sh' as the default entrypoint
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["bash","/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Development Container
+Utilize the docker image chasty2/ansible for development. Essentially just a homebrew Execution Environment. It uses SSH, host networking, and the user 'ansible' to run playbooks from a  directory that is bind-mounted to the container
+
+## Dependencies
+- A folder 'ssh-keys' with the public/private key the ansible user will use
+- A file 'vault.pass' with a vault password that the entrypoint will point to
+
+## Scripts
+- build-ansible.sh: Build a dev container with the tag 'latest'. Additional tags can be appended
+- run-ansible.sh: Run the container with podman and a specified directory with playbooks. See script for example usage. Add this script to your PATH for easy usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Development Container
-Utilize the docker image chasty2/ansible for development. Essentially just a homebrew Execution Environment. It uses SSH, host networking, and the user 'ansible' to run playbooks from a  directory that is bind-mounted to the container
+Utilize a custom docker image for development. Essentially just a homebrew Execution Environment. It uses SSH, host networking, and the user 'ansible' to run playbooks from a  directory that is bind-mounted to the container
 
 ## Dependencies
 - A folder 'ssh-keys' with the public/private key the ansible user will use

--- a/build-ansible.sh
+++ b/build-ansible.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+## script to build ansible container with tag 'latest'
+## Written by Cody Hasty
+
+# Example use: ./build-ansible.sh [-t ansible-crowsnet:version_number]
+
+#
+## Arguments to podman
+#
+# .							                specify Dockerfile in working directory 
+# -t container_name:tag					    name and tag container
+# $@                                        (optional) specify additional tags
+
+podman build . -t ansible-crowsnet:latest $@

--- a/configs/hosts
+++ b/configs/hosts
@@ -1,4 +1,0 @@
-# example hosts file in YAML
-homelab:
-  hosts:
-    192.168.4.33  # vorel

--- a/configs/playbook.yml
+++ b/configs/playbook.yml
@@ -1,5 +1,0 @@
-# example playbook
-- hosts: homelab
-  tasks:
-    - name: ping vorel
-      ping:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ansible-playbook $1
+ansible-playbook --vault-password-file vault.pass $@

--- a/run-ansible.sh
+++ b/run-ansible.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## script to run ansible container with a given playbook
+## Written by Cody Hasty
+
+# Example use: ./run_ansible.sh playbook.yml [--tags tag_name]
+
+#
+## Arguments to podman
+#
+# -it							            interactive mode 
+# --rm							            delete container after use
+# --network host					        use IP address of host VM
+#--volume ANSIBLE_DIRECTORY:/etc/ansible 	point /etc/ansible in container to ansible directory in host
+# -w /etc/ansible 					        set /etc/ansible as working directory inside container
+# ansible_crowsnet					        specify container
+# $@ 							            specify a playbook at command line when running this script (and optionally tags, etc)
+
+ANSIBLE_DIRECTORY="/home/chasty2/ansible_crowsnet"
+
+podman run -it --rm --network host --volume $ANSIBLE_DIRECTORY:/etc/ansible -w /etc/ansible ansible-crowsnet $@


### PR DESCRIPTION
Better ways of doing ansible development exist, and I think they should be used instead of this homebrew container. For this reason, I'm going to merge my template ansible container with the downsteam one I use for development on my homelab. I don't think the template will be used for anything else going forward. I will eventually phase it out of my homelab as well, replacing it with Molecule and AWX